### PR TITLE
Update kotlin to be more idiomatic

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -33,4 +33,8 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+
+    buildFeatures {
+        viewBinding true
+    }
 }

--- a/exoplayer-codelab-00/src/main/java/com/example/exoplayer/PlayerActivity.kt
+++ b/exoplayer-codelab-00/src/main/java/com/example/exoplayer/PlayerActivity.kt
@@ -17,13 +17,17 @@ package com.example.exoplayer
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import com.example.exoplayer.databinding.ActivityPlayerBinding
 
 /**
  * A fullscreen activity to play audio or video streams.
  */
 class PlayerActivity : AppCompatActivity() {
+
+    private val viewBinding by lazy { ActivityPlayerBinding.inflate(layoutInflater) }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_player)
+        setContentView(viewBinding.root)
     }
 }

--- a/exoplayer-codelab-01/src/main/java/com/example/exoplayer/PlayerActivity.kt
+++ b/exoplayer-codelab-01/src/main/java/com/example/exoplayer/PlayerActivity.kt
@@ -72,27 +72,27 @@ class PlayerActivity : AppCompatActivity() {
     }
 
     private fun initializePlayer() {
-        val nonNullPlayer = SimpleExoPlayer.Builder(this).build()
-        player = nonNullPlayer
+        player = SimpleExoPlayer.Builder(this)
+            .build()
+            .also {
+                viewBinding.videoView.player = it
 
-        viewBinding.videoView.player = nonNullPlayer
-
-        val mediaItem = MediaItem.fromUri(getString(R.string.media_url_mp4))
-        nonNullPlayer.setMediaItem(mediaItem)
-        nonNullPlayer.playWhenReady = playWhenReady
-        nonNullPlayer.seekTo(currentWindow, playbackPosition)
-        nonNullPlayer.prepare()
+                val mediaItem = MediaItem.fromUri(getString(R.string.media_url_mp4))
+                it.setMediaItem(mediaItem)
+                it.playWhenReady = playWhenReady
+                it.seekTo(currentWindow, playbackPosition)
+                it.prepare()
+            }
     }
 
     private fun releasePlayer() {
-        val nullablePlayer = player
-        if (nullablePlayer != null) {
-            playbackPosition = nullablePlayer.currentPosition
-            currentWindow = nullablePlayer.currentWindowIndex
-            playWhenReady = nullablePlayer.playWhenReady
-            nullablePlayer.release()
-            player = null
+        player?.let {
+            playbackPosition = it.currentPosition
+            currentWindow = it.currentWindowIndex
+            playWhenReady = it.playWhenReady
+            it.release()
         }
+        player = null
     }
 
     @SuppressLint("InlinedApi")

--- a/exoplayer-codelab-01/src/main/java/com/example/exoplayer/PlayerActivity.kt
+++ b/exoplayer-codelab-01/src/main/java/com/example/exoplayer/PlayerActivity.kt
@@ -19,24 +19,27 @@ import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import com.example.exoplayer.databinding.ActivityPlayerBinding
 import com.google.android.exoplayer2.MediaItem
 import com.google.android.exoplayer2.SimpleExoPlayer
-import com.google.android.exoplayer2.ui.PlayerView
 import com.google.android.exoplayer2.util.Util
 
 /**
  * A fullscreen activity to play audio or video streams.
  */
 class PlayerActivity : AppCompatActivity() {
-    private var playerView: PlayerView? = null
+
+    private val viewBinding by lazy { ActivityPlayerBinding.inflate(layoutInflater) }
+
     private var player: SimpleExoPlayer? = null
+
     private var playWhenReady = true
     private var currentWindow = 0
     private var playbackPosition: Long = 0
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_player)
-        playerView = findViewById(R.id.video_view)
+        setContentView(viewBinding.root)
     }
 
     public override fun onStart() {
@@ -69,28 +72,32 @@ class PlayerActivity : AppCompatActivity() {
     }
 
     private fun initializePlayer() {
-        player = SimpleExoPlayer.Builder(this).build()
-        playerView!!.player = player
+        val nonNullPlayer = SimpleExoPlayer.Builder(this).build()
+        player = nonNullPlayer
+
+        viewBinding.videoView.player = nonNullPlayer
+
         val mediaItem = MediaItem.fromUri(getString(R.string.media_url_mp4))
-        player!!.setMediaItem(mediaItem)
-        player!!.playWhenReady = playWhenReady
-        player!!.seekTo(currentWindow, playbackPosition)
-        player!!.prepare()
+        nonNullPlayer.setMediaItem(mediaItem)
+        nonNullPlayer.playWhenReady = playWhenReady
+        nonNullPlayer.seekTo(currentWindow, playbackPosition)
+        nonNullPlayer.prepare()
     }
 
     private fun releasePlayer() {
-        if (player != null) {
-            playbackPosition = player!!.currentPosition
-            currentWindow = player!!.currentWindowIndex
-            playWhenReady = player!!.playWhenReady
-            player!!.release()
+        val nullablePlayer = player
+        if (nullablePlayer != null) {
+            playbackPosition = nullablePlayer.currentPosition
+            currentWindow = nullablePlayer.currentWindowIndex
+            playWhenReady = nullablePlayer.playWhenReady
+            nullablePlayer.release()
             player = null
         }
     }
 
     @SuppressLint("InlinedApi")
     private fun hideSystemUi() {
-        playerView!!.systemUiVisibility = (View.SYSTEM_UI_FLAG_LOW_PROFILE
+        viewBinding.videoView.systemUiVisibility = (View.SYSTEM_UI_FLAG_LOW_PROFILE
                 or View.SYSTEM_UI_FLAG_FULLSCREEN
                 or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
                 or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY

--- a/exoplayer-codelab-02/src/main/java/com/example/exoplayer/PlayerActivity.kt
+++ b/exoplayer-codelab-02/src/main/java/com/example/exoplayer/PlayerActivity.kt
@@ -19,24 +19,27 @@ import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import com.example.exoplayer.databinding.ActivityPlayerBinding
 import com.google.android.exoplayer2.MediaItem
 import com.google.android.exoplayer2.SimpleExoPlayer
-import com.google.android.exoplayer2.ui.PlayerView
 import com.google.android.exoplayer2.util.Util
 
 /**
  * A fullscreen activity to play audio or video streams.
  */
 class PlayerActivity : AppCompatActivity() {
-    private var playerView: PlayerView? = null
+
+    private val viewBinding by lazy { ActivityPlayerBinding.inflate(layoutInflater) }
+
     private var player: SimpleExoPlayer? = null
+
     private var playWhenReady = true
     private var currentWindow = 0
     private var playbackPosition: Long = 0
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_player)
-        playerView = findViewById(R.id.video_view)
+        setContentView(viewBinding.root)
     }
 
     public override fun onStart() {
@@ -69,30 +72,34 @@ class PlayerActivity : AppCompatActivity() {
     }
 
     private fun initializePlayer() {
-        player = SimpleExoPlayer.Builder(this).build()
-        playerView!!.player = player
+        val nonNullPlayer = SimpleExoPlayer.Builder(this).build()
+        player = nonNullPlayer
+
+        viewBinding.videoView.player = nonNullPlayer
+
         val mediaItem = MediaItem.fromUri(getString(R.string.media_url_mp4))
-        player!!.setMediaItem(mediaItem)
+        nonNullPlayer.setMediaItem(mediaItem)
         val secondMediaItem = MediaItem.fromUri(getString(R.string.media_url_mp3))
-        player!!.addMediaItem(secondMediaItem)
-        player!!.playWhenReady = playWhenReady
-        player!!.seekTo(currentWindow, playbackPosition)
-        player!!.prepare()
+        nonNullPlayer.addMediaItem(secondMediaItem)
+        nonNullPlayer.playWhenReady = playWhenReady
+        nonNullPlayer.seekTo(currentWindow, playbackPosition)
+        nonNullPlayer.prepare()
     }
 
     private fun releasePlayer() {
-        if (player != null) {
-            playbackPosition = player!!.currentPosition
-            currentWindow = player!!.currentWindowIndex
-            playWhenReady = player!!.playWhenReady
-            player!!.release()
+        val nullablePlayer = player
+        if (nullablePlayer != null) {
+            playbackPosition = nullablePlayer.currentPosition
+            currentWindow = nullablePlayer.currentWindowIndex
+            playWhenReady = nullablePlayer.playWhenReady
+            nullablePlayer.release()
             player = null
         }
     }
 
     @SuppressLint("InlinedApi")
     private fun hideSystemUi() {
-        playerView!!.systemUiVisibility = (View.SYSTEM_UI_FLAG_LOW_PROFILE
+        viewBinding.videoView.systemUiVisibility = (View.SYSTEM_UI_FLAG_LOW_PROFILE
                 or View.SYSTEM_UI_FLAG_FULLSCREEN
                 or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
                 or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY

--- a/exoplayer-codelab-02/src/main/java/com/example/exoplayer/PlayerActivity.kt
+++ b/exoplayer-codelab-02/src/main/java/com/example/exoplayer/PlayerActivity.kt
@@ -72,29 +72,29 @@ class PlayerActivity : AppCompatActivity() {
     }
 
     private fun initializePlayer() {
-        val nonNullPlayer = SimpleExoPlayer.Builder(this).build()
-        player = nonNullPlayer
+        player = SimpleExoPlayer.Builder(this)
+            .build()
+            .also {
+                viewBinding.videoView.player = it
 
-        viewBinding.videoView.player = nonNullPlayer
-
-        val mediaItem = MediaItem.fromUri(getString(R.string.media_url_mp4))
-        nonNullPlayer.setMediaItem(mediaItem)
-        val secondMediaItem = MediaItem.fromUri(getString(R.string.media_url_mp3))
-        nonNullPlayer.addMediaItem(secondMediaItem)
-        nonNullPlayer.playWhenReady = playWhenReady
-        nonNullPlayer.seekTo(currentWindow, playbackPosition)
-        nonNullPlayer.prepare()
+                val mediaItem = MediaItem.fromUri(getString(R.string.media_url_mp4))
+                it.setMediaItem(mediaItem)
+                val secondMediaItem = MediaItem.fromUri(getString(R.string.media_url_mp3))
+                it.addMediaItem(secondMediaItem)
+                it.playWhenReady = playWhenReady
+                it.seekTo(currentWindow, playbackPosition)
+                it.prepare()
+            }
     }
 
     private fun releasePlayer() {
-        val nullablePlayer = player
-        if (nullablePlayer != null) {
-            playbackPosition = nullablePlayer.currentPosition
-            currentWindow = nullablePlayer.currentWindowIndex
-            playWhenReady = nullablePlayer.playWhenReady
-            nullablePlayer.release()
-            player = null
+        player?.let {
+            playbackPosition = it.currentPosition
+            currentWindow = it.currentWindowIndex
+            playWhenReady = it.playWhenReady
+            it.release()
         }
+        player = null
     }
 
     @SuppressLint("InlinedApi")

--- a/exoplayer-codelab-03/src/main/java/com/example/exoplayer/PlayerActivity.kt
+++ b/exoplayer-codelab-03/src/main/java/com/example/exoplayer/PlayerActivity.kt
@@ -74,39 +74,34 @@ class PlayerActivity : AppCompatActivity() {
     }
 
     private fun initializePlayer() {
-        val currentPlayer = player
-        val nonNullPlayer = if (currentPlayer == null) {
-            val trackSelector = DefaultTrackSelector(this)
-            trackSelector.setParameters(
-                trackSelector.buildUponParameters().setMaxVideoSizeSd()
-            )
-            SimpleExoPlayer.Builder(this)
-                .setTrackSelector(trackSelector)
-                .build()
-        } else currentPlayer
-
-        player = nonNullPlayer
-        viewBinding.videoView.player = nonNullPlayer
-
-        val mediaItem = MediaItem.Builder()
-            .setUri(getString(R.string.media_url_dash))
-            .setMimeType(MimeTypes.APPLICATION_MPD)
+        val trackSelector = DefaultTrackSelector(this).apply {
+            setParameters(buildUponParameters().setMaxVideoSizeSd())
+        }
+        player = SimpleExoPlayer.Builder(this)
+            .setTrackSelector(trackSelector)
             .build()
-        nonNullPlayer.setMediaItem(mediaItem)
-        nonNullPlayer.playWhenReady = playWhenReady
-        nonNullPlayer.seekTo(currentWindow, playbackPosition)
-        nonNullPlayer.prepare()
+            .also {
+                viewBinding.videoView.player = it
+
+                val mediaItem = MediaItem.Builder()
+                    .setUri(getString(R.string.media_url_dash))
+                    .setMimeType(MimeTypes.APPLICATION_MPD)
+                    .build()
+                it.setMediaItem(mediaItem)
+                it.playWhenReady = playWhenReady
+                it.seekTo(currentWindow, playbackPosition)
+                it.prepare()
+            }
     }
 
     private fun releasePlayer() {
-        val nullablePlayer = player
-        if (nullablePlayer != null) {
-            playbackPosition = nullablePlayer.currentPosition
-            currentWindow = nullablePlayer.currentWindowIndex
-            playWhenReady = nullablePlayer.playWhenReady
-            nullablePlayer.release()
-            player = null
+        player?.let {
+            playbackPosition = it.currentPosition
+            currentWindow = it.currentWindowIndex
+            playWhenReady = it.playWhenReady
+            it.release()
         }
+        player = null
     }
 
     @SuppressLint("InlinedApi")

--- a/exoplayer-codelab-03/src/main/java/com/example/exoplayer/PlayerActivity.kt
+++ b/exoplayer-codelab-03/src/main/java/com/example/exoplayer/PlayerActivity.kt
@@ -19,10 +19,10 @@ import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import com.example.exoplayer.databinding.ActivityPlayerBinding
 import com.google.android.exoplayer2.MediaItem
 import com.google.android.exoplayer2.SimpleExoPlayer
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector
-import com.google.android.exoplayer2.ui.PlayerView
 import com.google.android.exoplayer2.util.MimeTypes
 import com.google.android.exoplayer2.util.Util
 
@@ -30,15 +30,18 @@ import com.google.android.exoplayer2.util.Util
  * A fullscreen activity to play audio or video streams.
  */
 class PlayerActivity : AppCompatActivity() {
-    private var playerView: PlayerView? = null
+
+    private val viewBinding by lazy { ActivityPlayerBinding.inflate(layoutInflater) }
+
     private var player: SimpleExoPlayer? = null
+
     private var playWhenReady = true
     private var currentWindow = 0
     private var playbackPosition: Long = 0
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_player)
-        playerView = findViewById(R.id.video_view)
+        setContentView(viewBinding.root)
     }
 
     public override fun onStart() {
@@ -71,39 +74,44 @@ class PlayerActivity : AppCompatActivity() {
     }
 
     private fun initializePlayer() {
-        if (player == null) {
+        val currentPlayer = player
+        val nonNullPlayer = if (currentPlayer == null) {
             val trackSelector = DefaultTrackSelector(this)
             trackSelector.setParameters(
                 trackSelector.buildUponParameters().setMaxVideoSizeSd()
             )
-            player = SimpleExoPlayer.Builder(this)
+            SimpleExoPlayer.Builder(this)
                 .setTrackSelector(trackSelector)
                 .build()
-        }
-        playerView!!.player = player
+        } else currentPlayer
+
+        player = nonNullPlayer
+        viewBinding.videoView.player = nonNullPlayer
+
         val mediaItem = MediaItem.Builder()
             .setUri(getString(R.string.media_url_dash))
             .setMimeType(MimeTypes.APPLICATION_MPD)
             .build()
-        player!!.setMediaItem(mediaItem)
-        player!!.playWhenReady = playWhenReady
-        player!!.seekTo(currentWindow, playbackPosition)
-        player!!.prepare()
+        nonNullPlayer.setMediaItem(mediaItem)
+        nonNullPlayer.playWhenReady = playWhenReady
+        nonNullPlayer.seekTo(currentWindow, playbackPosition)
+        nonNullPlayer.prepare()
     }
 
     private fun releasePlayer() {
-        if (player != null) {
-            playbackPosition = player!!.currentPosition
-            currentWindow = player!!.currentWindowIndex
-            playWhenReady = player!!.playWhenReady
-            player!!.release()
+        val nullablePlayer = player
+        if (nullablePlayer != null) {
+            playbackPosition = nullablePlayer.currentPosition
+            currentWindow = nullablePlayer.currentWindowIndex
+            playWhenReady = nullablePlayer.playWhenReady
+            nullablePlayer.release()
             player = null
         }
     }
 
     @SuppressLint("InlinedApi")
     private fun hideSystemUi() {
-        playerView!!.systemUiVisibility = (View.SYSTEM_UI_FLAG_LOW_PROFILE
+        viewBinding.videoView.systemUiVisibility = (View.SYSTEM_UI_FLAG_LOW_PROFILE
                 or View.SYSTEM_UI_FLAG_FULLSCREEN
                 or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
                 or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY

--- a/exoplayer-codelab-04/src/main/java/com/example/exoplayer/PlayerActivity.kt
+++ b/exoplayer-codelab-04/src/main/java/com/example/exoplayer/PlayerActivity.kt
@@ -80,42 +80,36 @@ class PlayerActivity : AppCompatActivity() {
     }
 
     private fun initializePlayer() {
-        val currentPlayer = player
-        val nonNullPlayer = if (currentPlayer == null) {
-            val trackSelector = DefaultTrackSelector(this)
-            trackSelector.setParameters(
-                trackSelector.buildUponParameters().setMaxVideoSizeSd()
-            )
-            SimpleExoPlayer.Builder(this)
-                .setTrackSelector(trackSelector)
-                .build()
+        val trackSelector = DefaultTrackSelector(this).apply {
+            setParameters(buildUponParameters().setMaxVideoSizeSd())
         }
-        else currentPlayer
-
-        player = nonNullPlayer
-        viewBinding.videoView.player = nonNullPlayer
-
-        val mediaItem = MediaItem.Builder()
-            .setUri(getString(R.string.media_url_dash))
-            .setMimeType(MimeTypes.APPLICATION_MPD)
+        player = SimpleExoPlayer.Builder(this)
+            .setTrackSelector(trackSelector)
             .build()
-        nonNullPlayer.setMediaItem(mediaItem)
-        nonNullPlayer.playWhenReady = playWhenReady
-        nonNullPlayer.seekTo(currentWindow, playbackPosition)
-        nonNullPlayer.addListener(playbackStateListener)
-        nonNullPlayer.prepare()
+            .also {
+                viewBinding.videoView.player = it
+
+                val mediaItem = MediaItem.Builder()
+                    .setUri(getString(R.string.media_url_dash))
+                    .setMimeType(MimeTypes.APPLICATION_MPD)
+                    .build()
+                it.setMediaItem(mediaItem)
+                it.playWhenReady = playWhenReady
+                it.seekTo(currentWindow, playbackPosition)
+                it.addListener(playbackStateListener)
+                it.prepare()
+            }
     }
 
     private fun releasePlayer() {
-        val nullablePlayer = player
-        if (nullablePlayer != null) {
-            playbackPosition = nullablePlayer.currentPosition
-            currentWindow = nullablePlayer.currentWindowIndex
-            playWhenReady = nullablePlayer.playWhenReady
-            nullablePlayer.removeListener(playbackStateListener)
-            nullablePlayer.release()
-            player = null
+        player?.let {
+            playbackPosition = it.currentPosition
+            currentWindow = it.currentWindowIndex
+            playWhenReady = it.playWhenReady
+            it.removeListener(playbackStateListener)
+            it.release()
         }
+        player = null
     }
 
     @SuppressLint("InlinedApi")


### PR DESCRIPTION
Updates the kotlin to be more idiomatic (gets rid of the !! force null unwrapping mostly).

I favored more descriptive variable names over more idiomatic lambdas for beginner accessibility.

For example:

```kotlin
    private fun releasePlayer() {
        val nullablePlayer = player
        if (nullablePlayer != null) {
            playbackPosition = nullablePlayer.currentPosition
            currentWindow = nullablePlayer.currentWindowIndex
            playWhenReady = nullablePlayer.playWhenReady
            nullablePlayer.release()
            player = null
        }
    }
```

versus

```kotlin
        player?.let {
            playbackPosition = it.currentPosition
            currentWindow = it.currentWindowIndex
            playWhenReady = it.playWhenReady
            it.release()
        }
        player = null
    }
```

Let me know what you think.